### PR TITLE
Add mobile friendly navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,14 +11,119 @@
     th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
     .status-complete { background-color: #d4edda; }
     .status-incomplete { background-color: #f8d7da; }
+
+    /* simple bottom navigation optimised for touch */
+    nav {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      background: #f0f0f0;
+      border-top: 1px solid #ccc;
+      justify-content: space-around;
+      padding: 10px 0;
+    }
+    nav a {
+      color: #333;
+      text-decoration: none;
+      font-size: 18px;
+    }
+    nav a.active {
+      font-weight: bold;
+    }
+    body {
+      padding-bottom: 70px; /* avoid content under nav */
+      margin: 0;
+      font-family: Arial, sans-serif;
+    }
   </style>
 </head>
 <body>
   <div id="root"></div>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js" crossorigin></script>
   <script type="text/babel">
+    const { BrowserRouter, Routes, Route, NavLink } = ReactRouterDOM;
+
+    function GoalsPage({ entries, form, handleChange, addEntry }) {
+      return (
+        <div>
+          <h1>Weekly Goals</h1>
+          <table>
+            <thead>
+              <tr>
+                <th>Week</th>
+                <th>Goal</th>
+                <th>Actual</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry, idx) => {
+                const completed = entry.goal && entry.actual && entry.goal.trim() === entry.actual.trim();
+                return (
+                  <tr key={idx} className={completed ? 'status-complete' : 'status-incomplete'}>
+                    <td>{entry.week}</td>
+                    <td>{entry.goal}</td>
+                    <td>{entry.actual}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <h2>Add/Update Week</h2>
+          <div>
+            <input name="week" placeholder="Week" value={form.week} onChange={handleChange} />
+            <input name="goal" placeholder="Goal" value={form.goal} onChange={handleChange} />
+            <input name="actual" placeholder="Actual" value={form.actual} onChange={handleChange} />
+            <button onClick={addEntry}>Add</button>
+          </div>
+        </div>
+      );
+    }
+
+    function WeightPage({ height, handleHeightChange, weightEntries, weightForm, handleWeightChange, addWeightEntry }) {
+      return (
+        <div>
+          <h1>Weight Tracker</h1>
+          <div>
+            <input placeholder="Height (m)" value={height} onChange={handleHeightChange} />
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Week</th>
+                <th>Weight (kg)</th>
+                <th>BMI</th>
+              </tr>
+            </thead>
+            <tbody>
+              {weightEntries.map((entry, idx) => {
+                const h = parseFloat(height);
+                const w = parseFloat(entry.weight);
+                const bmi = h ? (w / (h * h)).toFixed(2) : '';
+                return (
+                  <tr key={idx}>
+                    <td>{entry.week}</td>
+                    <td>{entry.weight}</td>
+                    <td>{bmi}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <h2>Add Weight</h2>
+          <div>
+            <input name="week" placeholder="Week" value={weightForm.week} onChange={handleWeightChange} />
+            <input name="weight" placeholder="Weight (kg)" value={weightForm.weight} onChange={handleWeightChange} />
+            <button onClick={addWeightEntry}>Add</button>
+          </div>
+        </div>
+      );
+    }
+
     function App() {
       const [entries, setEntries] = React.useState([
         { week: '2024-01-01', goal: 'Run 5 miles', actual: 'Run 5 miles' },
@@ -57,71 +162,18 @@
       };
 
       return (
-        <div>
-          <h1>Weekly Goals</h1>
-          <table>
-            <thead>
-              <tr>
-                <th>Week</th>
-                <th>Goal</th>
-                <th>Actual</th>
-              </tr>
-            </thead>
-            <tbody>
-              {entries.map((entry, idx) => {
-                const completed = entry.goal && entry.actual && entry.goal.trim() === entry.actual.trim();
-                return (
-                  <tr key={idx} className={completed ? 'status-complete' : 'status-incomplete'}>
-                    <td>{entry.week}</td>
-                    <td>{entry.goal}</td>
-                    <td>{entry.actual}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          <h2>Add/Update Week</h2>
-          <div>
-            <input name="week" placeholder="Week" value={form.week} onChange={handleChange} />
-            <input name="goal" placeholder="Goal" value={form.goal} onChange={handleChange} />
-            <input name="actual" placeholder="Actual" value={form.actual} onChange={handleChange} />
-            <button onClick={addEntry}>Add</button>
+        <BrowserRouter>
+          <div className="content">
+            <Routes>
+              <Route path="/" element={<GoalsPage entries={entries} form={form} handleChange={handleChange} addEntry={addEntry} />} />
+              <Route path="/weight" element={<WeightPage height={height} handleHeightChange={handleHeightChange} weightEntries={weightEntries} weightForm={weightForm} handleWeightChange={handleWeightChange} addWeightEntry={addWeightEntry} />} />
+            </Routes>
           </div>
-
-          <h1>Weight Tracker</h1>
-          <div>
-            <input placeholder="Height (m)" value={height} onChange={handleHeightChange} />
-          </div>
-          <table>
-            <thead>
-              <tr>
-                <th>Week</th>
-                <th>Weight (kg)</th>
-                <th>BMI</th>
-              </tr>
-            </thead>
-            <tbody>
-              {weightEntries.map((entry, idx) => {
-                const h = parseFloat(height);
-                const w = parseFloat(entry.weight);
-                const bmi = h ? (w / (h * h)).toFixed(2) : '';
-                return (
-                  <tr key={idx}>
-                    <td>{entry.week}</td>
-                    <td>{entry.weight}</td>
-                    <td>{bmi}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          <h2>Add Weight</h2>
-          <div>
-            <input name="week" placeholder="Week" value={weightForm.week} onChange={handleWeightChange} />
-            <input name="weight" placeholder="Weight (kg)" value={weightForm.weight} onChange={handleWeightChange} />
-            <button onClick={addWeightEntry}>Add</button>
-          </div>
-        </div>
+          <nav>
+            <NavLink to="/" end>Goals</NavLink>
+            <NavLink to="/weight">Weight</NavLink>
+          </nav>
+        </BrowserRouter>
       );
     }
 


### PR DESCRIPTION
## Summary
- add touch-friendly bottom navigation CSS
- integrate `react-router-dom` and split content into Goals and Weight pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b033628a4832d9ab2a33ba7cff270