### PR TITLE
Enable early on-screen logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,12 +62,49 @@
     }
   </style>
 </head>
-<body>
-  <div id="root"></div>
-  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js" crossorigin></script>
+  <body>
+    <div id="root"></div>
+    <script>
+      (function() {
+        const overlay = document.createElement('div');
+        overlay.id = 'console-overlay';
+        overlay.style.display = 'none';
+        const pre = document.createElement('pre');
+        overlay.appendChild(pre);
+
+        const btn = document.createElement('button');
+        btn.id = 'console-btn';
+        btn.textContent = 'Console';
+        btn.addEventListener('click', () => {
+          overlay.style.display = overlay.style.display === 'none' ? 'block' : 'none';
+        });
+
+        document.body.appendChild(btn);
+        document.body.appendChild(overlay);
+
+        function append(type, args) {
+          pre.textContent += `[${type}] ${Array.from(args).join(' ')}\n`;
+          overlay.scrollTop = overlay.scrollHeight;
+        }
+
+        const origLog = console.log;
+        console.log = (...args) => { origLog(...args); append('LOG', args); };
+        const origErr = console.error;
+        console.error = (...args) => {
+          origErr(...args);
+          append('ERROR', args);
+          overlay.style.display = 'block';
+        };
+        window.addEventListener('error', e => {
+          append('ERROR', [e.message]);
+          overlay.style.display = 'block';
+        });
+      })();
+    </script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js" crossorigin></script>
   <script type="text/babel">
     const { HashRouter, Routes, Route, NavLink } = ReactRouterDOM;
 
@@ -157,32 +194,6 @@
       const [height, setHeight] = React.useState('');
       const [weightEntries, setWeightEntries] = React.useState([]);
       const [weightForm, setWeightForm] = React.useState({ week: '', weight: '' });
-      const [logs, setLogs] = React.useState([]);
-      const [consoleVisible, setConsoleVisible] = React.useState(false);
-
-      React.useEffect(() => {
-        const origLog = console.log;
-        const origErr = console.error;
-        console.log = (...args) => {
-          origLog(...args);
-          setLogs(prev => [...prev, `[LOG] ${args.join(' ')}`]);
-        };
-        console.error = (...args) => {
-          origErr(...args);
-          setLogs(prev => [...prev, `[ERROR] ${args.join(' ')}`]);
-          setConsoleVisible(true);
-        };
-        const handleError = (e) => {
-          setLogs(prev => [...prev, `[ERROR] ${e.message}`]);
-          setConsoleVisible(true);
-        };
-        window.addEventListener('error', handleError);
-        return () => {
-          console.log = origLog;
-          console.error = origErr;
-          window.removeEventListener('error', handleError);
-        };
-      }, []);
 
       const handleChange = (e) => {
         setForm({ ...form, [e.target.name]: e.target.value });
@@ -222,14 +233,6 @@
             <NavLink to="/" end>Goals</NavLink>
             <NavLink to="/weight">Weight</NavLink>
           </nav>
-          <button id="console-btn" onClick={() => setConsoleVisible(v => !v)}>Console</button>
-          {consoleVisible && (
-            <div id="console-overlay">
-              <button onClick={() => setConsoleVisible(false)}>Dismiss</button>
-              <button onClick={() => navigator.clipboard.writeText(logs.join('\n'))}>Copy</button>
-              <pre>{logs.join('\n')}</pre>
-            </div>
-          )}
         </HashRouter>
       );
     }


### PR DESCRIPTION
## Summary
- Add inline startup script to display console logs/errors in a toggleable on-screen overlay before other scripts load
- Remove React-based logging overlay and related state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907aad33b4832d9939c6356670bafe