### PR TITLE
Fix ReactRouterDOM reference error

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,15 @@
     <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js" crossorigin></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js" crossorigin></script>
   <script type="text/babel">
-    const { HashRouter, Routes, Route, NavLink } = ReactRouterDOM;
+    // React Router is loaded from a CDN and exposes a global `ReactRouterDOM`.
+    // Some environments threw a ReferenceError because the global variable
+    // was accessed directly before it existed on `window`. To avoid that we
+    // first reference the property on `window` and warn if it is missing.
+    const ReactRouterDOM = window.ReactRouterDOM;
+    if (!ReactRouterDOM) {
+      console.error('React Router DOM failed to load');
+    }
+    const { HashRouter, Routes, Route, NavLink } = ReactRouterDOM || {};
 
     function GoalsPage({ entries, form, handleChange, addEntry }) {
       return (


### PR DESCRIPTION
## Summary
- Safely load React Router DOM from `window` and log a helpful error when it isn’t available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68908b8fa910832da42d4858258d3dcd