### PR TITLE
Handle missing React Router DOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,10 @@
     }
 
     function App() {
+      if (!HashRouter || !Routes || !Route || !NavLink) {
+        return <div>React Router DOM failed to load.</div>;
+      }
+
       const [entries, setEntries] = React.useState([
         { week: '2024-01-01', goal: 'Run 5 miles', actual: 'Run 5 miles' },
         { week: '2024-01-08', goal: 'Read a book', actual: 'Half a book' },


### PR DESCRIPTION
## Summary
- avoid rendering undefined React Router DOM components
- show a simple error message when React Router DOM fails to load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890b14a370c832d98cbfb978552c811