### PR TITLE
Add SessionStart hook for gh CLI auth

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Configure gh CLI to use the egress proxy for GitHub API access
+if [ -n "${GLOBAL_AGENT_HTTP_PROXY:-}" ]; then
+  echo "export HTTPS_PROXY=\"${GLOBAL_AGENT_HTTP_PROXY}\"" >> "$CLAUDE_ENV_FILE"
+  echo "export HTTP_PROXY=\"${GLOBAL_AGENT_HTTP_PROXY}\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+# Authenticate gh CLI if GH_TOKEN is available
+if [ -n "${GH_TOKEN:-}" ]; then
+  echo "$GH_TOKEN" | gh auth login --with-token 2>/dev/null || true
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Claude Code SessionStart hook that configures HTTPS/HTTP proxy and authenticates `gh` CLI in remote sessions
- Registers the hook in `.claude/settings.json` so it runs automatically on session start
- Only activates in remote (Claude Code on the web) environments; no-op locally

## Test plan
- [x] Verified hook runs successfully and writes proxy config to env file
- [x] Confirmed GitHub API is reachable through proxy
- [ ] Set `GH_TOKEN` env var and verify `gh pr create` works end-to-end

https://claude.ai/code/session_01NSeCSc6EknNQGYXrKZFtwx