### PR TITLE
Improve clarity of the zoom-to-trade control

### DIFF
--- a/index.html
+++ b/index.html
@@ -734,6 +734,26 @@
     }
     .zoom-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
     .zoom-btn:active { transform: scale(0.92); }
+    .zoom-btn-trade {
+      width: auto;
+      padding: 0 10px;
+      gap: 6px;
+      font-size: 12px;
+      color: var(--accent-blue);
+      border-color: rgba(59,130,246,0.55);
+      background: rgba(59,130,246,0.1);
+    }
+    .zoom-btn-trade:hover {
+      background: rgba(59,130,246,0.2);
+      color: #dbeafe;
+      border-color: rgba(59,130,246,0.8);
+    }
+    .zoom-btn-trade:disabled {
+      opacity: 0.5;
+      border-color: var(--border);
+      color: var(--text-muted);
+      background: var(--bg-secondary);
+    }
     .zoom-label {
       font-size: 11px;
       font-family: 'JetBrains Mono', monospace;
@@ -2057,13 +2077,13 @@
                     setZoom(newZoom);
                   }} aria-label="Zoom in" disabled={zoom >= 10}>+</button>
                   <button
-                    className="zoom-btn"
+                    className="zoom-btn zoom-btn-trade"
                     onClick={zoomToActiveTrade}
                     aria-label="Zoom to active trade"
                     title={activeTrade ? 'Zoom to active trade' : 'No active trade'}
                     disabled={!activeTrade}
                   >
-                    Trade
+                    🎯 Trade Focus
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation

- The zoom controls contained a small unlabeled `Trade` button that blended with the +/- zoom buttons and was hard to discover. 
- The change aims to improve affordance and make the action explicit while preserving existing behavior and accessibility attributes.

### Description

- Added a new CSS rule set `.zoom-btn-trade` to give the zoom-to-trade button wider padding, accent coloring, hover styling, and a clear disabled state. 
- Replaced the button label from `Trade` to `🎯 Trade Focus` and applied the `zoom-btn-trade` class while keeping the `zoomToActiveTrade` click handler and `aria-label` intact. 
- The modification is confined to `index.html` and only affects presentation and label text; no changes were made to the zoom logic.

### Testing

- Ran `git diff --check` which produced no style errors. 
- Attempted to run a local HTTP server with `python3 -m http.server 4173` and capture a screenshot via Playwright, but the server process did not remain reachable in this environment so the browser capture failed. 
- The change was committed successfully and the repository diff shows a single file update to `index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e3564a66c832d8f0877ec761fcfb5)